### PR TITLE
Update template conditions in automation files to check for user_id

### DIFF
--- a/automation/binary_light_timer.yaml
+++ b/automation/binary_light_timer.yaml
@@ -108,7 +108,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/binary_light_timer_condition.yaml
+++ b/automation/binary_light_timer_condition.yaml
@@ -133,7 +133,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/binary_light_timer_condition_illuminance.yaml
+++ b/automation/binary_light_timer_condition_illuminance.yaml
@@ -149,7 +149,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/binary_light_timer_condition_illuminance_main.yaml
+++ b/automation/binary_light_timer_condition_illuminance_main.yaml
@@ -183,7 +183,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/binary_light_timer_condition_main.yaml
+++ b/automation/binary_light_timer_condition_main.yaml
@@ -149,7 +149,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/motion_light_timer.yaml
+++ b/automation/motion_light_timer.yaml
@@ -108,7 +108,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/motion_light_timer_condition.yaml
+++ b/automation/motion_light_timer_condition.yaml
@@ -121,7 +121,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/motion_light_timer_condition_illuminance.yaml
+++ b/automation/motion_light_timer_condition_illuminance.yaml
@@ -137,7 +137,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/motion_light_timer_condition_illuminance_main.yaml
+++ b/automation/motion_light_timer_condition_illuminance_main.yaml
@@ -156,7 +156,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:

--- a/automation/motion_light_timer_condition_main.yaml
+++ b/automation/motion_light_timer_condition_main.yaml
@@ -140,7 +140,7 @@ action:
             entity_id: !input entity_target
             state: "on"
           - condition: template
-            value_template: "{{ trigger.to_state.context.id != context.id }}"
+            value_template: "{{ trigger.to_state.context.user_id is not none }}"
         sequence:
           - service: timer.start
             target:


### PR DESCRIPTION
This commit modifies the template conditions in multiple automation YAML files for both binary and motion light timers. The condition now checks if the user_id is not none, enhancing the logic for triggering actions based on user context.